### PR TITLE
Added an option to restrict the relative depth to which the plugin...

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The plugin is enabled by default, and can be disabled by copying `user/plugins/d
 |----------------|---------|-------------------|--------------------------------------------------------------------------|
 | `enabled` | `true` | `true` or `false` | Enables or disables plugin entirely. |
 | `level` | 1 | (int) 0-10 | Initial level of folders to expand on load. |
+| `max_depth`  | 3 | (int) 1-10 | Deepest depth to which to generate the tree. |
 | `links` | `true` | `true` or `false` | Enables or disables links on file names. |
 | `builtin_css` | `true` | `true` or `false` | Enables or disables the plugin's built-in CSS. |
 | `builtin_js` | `true` | `true` or `false` | Enables or disables the plugin's built-in JavaScript. |
@@ -71,8 +72,8 @@ You can also call the plugin from the `directorylisting` Twig-function, for exam
 
 ```
 {% set settings = {
-    'exclude_main': false, 
-    'exclude_modular': true, 
+    'exclude_main': false,
+    'exclude_modular': true,
     'include_additional': [
         '/blog'
     ]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The plugin is enabled by default, and can be disabled by copying `user/plugins/d
 | Variable | Default | Options | Note |
 |----------------|---------|-------------------|--------------------------------------------------------------------------|
 | `enabled` | `true` | `true` or `false` | Enables or disables plugin entirely. |
-| `level` | 1 | (int) 0-10 | Initial level of folders to expand on load. |
-| `max_depth`  | 3 | (int) 1-10 | Deepest depth to which to generate the tree. |
+| `level` | 1 | (int) 0-n | Initial level of folders to expand on load. |
+| `max_depth`  | 3 | (int) 1-n | Depth at which to stop generating the tree. |
 | `links` | `true` | `true` or `false` | Enables or disables links on file names. |
 | `builtin_css` | `true` | `true` or `false` | Enables or disables the plugin's built-in CSS. |
 | `builtin_js` | `true` | `true` or `false` | Enables or disables the plugin's built-in JavaScript. |

--- a/Utilities.php
+++ b/Utilities.php
@@ -73,29 +73,31 @@ class Utilities
         $pages = $page->evaluate([$mode => $route]);
         $pages = $pages->published()->order($config['order']['by'], $config['order']['dir']);
         $paths = array();
-        foreach ($pages as $page) {
-            if ($config['exclude_modular'] && isset($page->header()->content['items'])) {
-                if ($page->header()->content['items'] == '@self.modular') {
-                    continue;
-                }
-            }
-            $route = $page->rawRoute();
-            $path = $page->path();
-            $title = $page->title();
-            $paths[$route]['depth'] = $depth;
-            $paths[$route]['title'] = $title;
-            $paths[$route]['route'] = $route;
-            $paths[$route]['name'] = $page->name();
-            if (!empty($paths[$route])) {
-                $children = $this->buildTree($route, $mode, $depth);
-                if (!empty($children)) {
-                    $paths[$route]['children'] = $children;
-                }
-            }
-            $media = new Media($path);
-            foreach ($media->all() as $filename => $file) {
-                $paths[$route]['media'][$filename] = $file->items()['type'];
-            }
+        if ($depth <= $config['max_depth']) {
+          foreach ($pages as $page) {
+              if ($config['exclude_modular'] && isset($page->header()->content['items'])) {
+                  if ($page->header()->content['items'] == '@self.modular') {
+                      continue;
+                  }
+              }
+              $route = $page->rawRoute();
+              $path = $page->path();
+              $title = $page->title();
+              $paths[$route]['depth'] = $depth;
+              $paths[$route]['title'] = $title;
+              $paths[$route]['route'] = $route;
+              $paths[$route]['name'] = $page->name();
+              if (!empty($paths[$route])) {
+                  $children = $this->buildTree($route, $mode, $depth);
+                  if (!empty($children)) {
+                      $paths[$route]['children'] = $children;
+                  }
+              }
+              $media = new Media($path);
+              foreach ($media->all() as $filename => $file) {
+                  $paths[$route]['media'][$filename] = $file->items()['type'];
+              }
+          }
         }
         if (!empty($paths)) {
             return $paths;
@@ -157,7 +159,7 @@ class Utilities
 				    }
 				    $list .= '</ul>';
 
-			    } 
+			    }
 			    $list .= '</li>';
 		    }
 	    }

--- a/Utilities.php
+++ b/Utilities.php
@@ -74,30 +74,30 @@ class Utilities
         $pages = $pages->published()->order($config['order']['by'], $config['order']['dir']);
         $paths = array();
         if ($depth <= $config['max_depth']) {
-          foreach ($pages as $page) {
-              if ($config['exclude_modular'] && isset($page->header()->content['items'])) {
-                  if ($page->header()->content['items'] == '@self.modular') {
-                      continue;
-                  }
-              }
-              $route = $page->rawRoute();
-              $path = $page->path();
-              $title = $page->title();
-              $paths[$route]['depth'] = $depth;
-              $paths[$route]['title'] = $title;
-              $paths[$route]['route'] = $route;
-              $paths[$route]['name'] = $page->name();
-              if (!empty($paths[$route])) {
-                  $children = $this->buildTree($route, $mode, $depth);
-                  if (!empty($children)) {
-                      $paths[$route]['children'] = $children;
-                  }
-              }
-              $media = new Media($path);
-              foreach ($media->all() as $filename => $file) {
-                  $paths[$route]['media'][$filename] = $file->items()['type'];
-              }
-          }
+            foreach ($pages as $page) {
+                if ($config['exclude_modular'] && isset($page->header()->content['items'])) {
+                    if ($page->header()->content['items'] == '@self.modular') {
+                        continue;
+                    }
+                }
+                $route = $page->rawRoute();
+                $path = $page->path();
+                $title = $page->title();
+                $paths[$route]['depth'] = $depth;
+                $paths[$route]['title'] = $title;
+                $paths[$route]['route'] = $route;
+                $paths[$route]['name'] = $page->name();
+                if (!empty($paths[$route])) {
+                    $children = $this->buildTree($route, $mode, $depth);
+                    if (!empty($children)) {
+                        $paths[$route]['children'] = $children;
+                    }
+                }
+                $media = new Media($path);
+                foreach ($media->all() as $filename => $file) {
+                    $paths[$route]['media'][$filename] = $file->items()['type'];
+                }
+            }
         }
         if (!empty($paths)) {
             return $paths;

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -25,23 +25,23 @@ form:
       validate:
         type: bool
     level:
-      type: range
+      type: text
       label: Level
       description: Initial level of folders to expand on load.
       id: directorylisting_level
       default: 1
       validate:
+        type: int
         min: 0
-        max: 10
     max_depth:
       type: range
       label: Maximum Level
-      description: Deepest depth to which to generate the tree.
+      description: Depth at which to stop generating the tree.
       id: directorylisting_max_depth
       default: 3
       validate:
+        type: int
         min: 1
-        max: 10
     showfiles:
       type: toggle
       label: Show media files

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -33,6 +33,15 @@ form:
       validate:
         min: 0
         max: 10
+    max_depth:
+      type: range
+      label: Maximum Level
+      description: Deepest depth to which to generate the tree.
+      id: directorylisting_max_depth
+      default: 3
+      validate:
+        min: 1
+        max: 10
     showfiles:
       type: toggle
       label: Show media files

--- a/directorylisting.yaml
+++ b/directorylisting.yaml
@@ -1,6 +1,6 @@
 enabled: true
 level: 1
-max-depth: 3
+max_depth: 3
 showfiles: true
 links: true
 builtin_css: true

--- a/directorylisting.yaml
+++ b/directorylisting.yaml
@@ -1,5 +1,6 @@
 enabled: true
 level: 1
+max-depth: 3
 showfiles: true
 links: true
 builtin_css: true
@@ -10,6 +11,6 @@ order:
   by: date
   dir: desc
 include_additional:
- - 
+ -
 exclude_additional:
- - 
+ -


### PR DESCRIPTION
…will descend in Utilities.buildTree().

This is useful for users who have deeply nested pages but wish to 
provide navigation only among higher levels.